### PR TITLE
Allow uppercase in group and names

### DIFF
--- a/src/group.coffee
+++ b/src/group.coffee
@@ -23,7 +23,7 @@
 # Author:
 #   anishathalye
 
-IDENTIFIER = "[-._a-z0-9]+"
+IDENTIFIER = "[-._a-zA-Z0-9]+"
 
 class Group
   constructor: (@robot) ->


### PR DESCRIPTION
Services such as HipChat, names are case sensitive
